### PR TITLE
Add `--no-func-cov` flag and refactor DUT creation

### DIFF
--- a/toffee_test/plugin.py
+++ b/toffee_test/plugin.py
@@ -54,7 +54,7 @@ def pytest_runtest_setup(item):
     toffee_tags_process(item)
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: pytest.Parser):
     group = parser.getgroup("reporter")
     group.addoption(
         "--toffee-report",
@@ -82,12 +82,18 @@ def pytest_addoption(parser):
         "--custom-key-value",
         action="store",
         default=None,
-        help="Custom key value pair. dict wtih base64 encoded",
+        help="Custom key value pair. dict wtih base64 encoded.",
     )
 
+    group.addoption(
+        "--no-func-cov",
+        action="store_true",
+        default=False,
+        help="Run test without functional coverage.",
+    )
 
 @pytest.hookimpl(tryfirst=True)
-def pytest_configure(config):
+def pytest_configure(config: pytest.Config):
     config.addinivalue_line(
         "markers", "mlvp_async: mark test to run with toffee's event loop"
     )

--- a/toffee_test/request.py
+++ b/toffee_test/request.py
@@ -6,7 +6,8 @@ from .reporter import set_line_coverage
 
 
 class ToffeeRequest:
-    def __init__(self, request):
+    from pytest import FixtureRequest
+    def __init__(self, request: FixtureRequest):
         self.dut = None
         self.args = None
         self.request = request
@@ -32,21 +33,27 @@ class ToffeeRequest:
         for g in cov_groups:
             self.dut.xclock.StepRis(sample_helper(g))
 
-    def __need_report(self):
+    def __need_report(self) -> bool:
         """
         Whether to generate the report
         """
 
         return self.request.config.getoption("--toffee-report")
 
+    def __no_func(self) -> bool:
+        """
+        Whether to run test without functional coverage.
+        """
+        return self.request.config.getoption("--no-func-coverage")
+
     def create_dut(
-        self,
-        dut_cls,
-        clock_name=None,
-        waveform_filename=None,
-        coverage_filename=None,
-        dut_extra_args=(),
-        dut_extra_kwargs={},
+            self,
+            dut_cls,
+            clock_name=None,
+            waveform_filename=None,
+            coverage_filename=None,
+            *dut_extra_args,
+            **dut_extra_kwargs,
     ):
         """
         Create the DUT.
@@ -62,44 +69,53 @@ class ToffeeRequest:
             The DUT instance.
         """
 
-        final_kwargs = dict(dut_extra_kwargs)
+        dut_extra_kwargs["waveform_filename"] = ""
+        dut_extra_kwargs["coverage_filename"] = ""
 
-        if self.__need_report():
-            report_dir = os.path.dirname(self.request.config.option.report[0])
-            request_name = self.request.node.name
-            path_bytes = str(self.request.path).encode("utf-8")
-            path_hash = format(crc32(path_bytes), 'x')
-            export_filename = "_".join((dut_cls.__name__, request_name, path_hash))
+        # Create DUT
+        self.dut = dut_cls(*dut_extra_args, **dut_extra_kwargs)
 
-            self.waveform_filename = (
-                f"{report_dir}/{export_filename}.fst"
-            )
-            self.coverage_filename = (
-                f"{report_dir}/{export_filename}.dat"
-            )
-
-            if waveform_filename is not None:
-                self.waveform_filename = waveform_filename
-            if coverage_filename is not None:
-                self.coverage_filename = coverage_filename
-
-            final_kwargs["waveform_filename"] = self.waveform_filename
-            final_kwargs["coverage_filename"] = self.coverage_filename
-
-            self.dut = dut_cls(*dut_extra_args, **final_kwargs)
-
-            if self.cov_groups is not None:
-                self.__add_cov_sample(self.cov_groups)
-        else:
-            if waveform_filename is not None:
-                final_kwargs["waveform_filename"] = waveform_filename
-            if coverage_filename is not None:
-                final_kwargs["coverage_filename"] = coverage_filename
-
-            self.dut = dut_cls(*dut_extra_args, **final_kwargs)
-
+        # Set clock name
         if clock_name:
             self.dut.InitClock(clock_name)
+
+        # Options for running without waveform/coverage generation from the DUT.
+        wave_format: str = self.dut.GetWaveFormat()
+        use_code_cov: bool = self.dut.GetCovMetrics() != 0
+
+        # Set default export name when generate report
+        if self.__need_report():
+            # Default export file name
+            report_dir = os.path.dirname(self.request.config.option.report[0])  # Get report dir
+            request_name = self.request.node.name  # Get name of the case
+            path_bytes = str(self.request.path).encode("utf-8")
+            path_hash = format(crc32(path_bytes), 'x')  # Get the hash of the case file path
+            # Default export name is '{DUT_Class}_{request_name}_{path_hash}'
+            default_export_name = "_".join((dut_cls.__name__, request_name, path_hash))
+            # Set default waveform name
+            if wave_format:
+                default_name = ".".join((default_export_name, wave_format))
+                self.waveform_filename = "/".join((report_dir, default_name))
+            # Set default coverage name
+            if use_code_cov:
+                default_name = ".".join((default_export_name, "dat"))
+                self.coverage_filename = "/".join((report_dir, default_name))
+
+        # Also export functional coverage
+        if not self.__no_func() and self.cov_groups:
+            self.__add_cov_sample(self.cov_groups)
+
+        # Set waveform name
+        if wave_format:
+            if waveform_filename:
+                self.waveform_filename = ".".join((waveform_filename, wave_format))
+            self.dut.SetWaveform(self.waveform_filename)
+
+        # Set coverage name
+        if use_code_cov:
+            if coverage_filename:
+                self.coverage_filename = coverage_filename
+            self.dut.SetCoverage(self.coverage_filename)
 
         return self.dut
 
@@ -116,7 +132,7 @@ class ToffeeRequest:
             cov_groups = [cov_groups]
         self.cov_groups.extend(cov_groups)
 
-        if self.dut is not None and periodic_sample:
+        if self.dut is not None and not self.__no_func() and periodic_sample:
             self.__add_cov_sample(cov_groups)
 
     def finish(self, request):
@@ -127,9 +143,13 @@ class ToffeeRequest:
         if self.dut is not None:
             self.dut.Finish()
 
+            use_code_cov: bool = self.dut.GetCovMetrics() != 0
+
             if self.__need_report():
-                set_func_coverage(request, self.cov_groups)
-                set_line_coverage(request, self.coverage_filename)
+                if not self.__no_func():
+                    set_func_coverage(request, self.cov_groups)
+                if use_code_cov:
+                    set_line_coverage(request, self.coverage_filename)
 
         for g in self.cov_groups:
             g.clear()

--- a/toffee_test/utils.py
+++ b/toffee_test/utils.py
@@ -4,6 +4,9 @@ import subprocess
 import copy
 import json
 import base64
+import itertools
+import tempfile
+from typing import List, Iterable
 
 
 def exe_cmd(cmd):
@@ -39,7 +42,7 @@ def convert_line_coverage(line_coverage_list, output_dir):
             fign = [fign]
         assert isinstance(fign, list), f"Invalid data file: '{fign}'"
         assert os.path.exists(fdat), f"Invalid data file: '{fdat}'"
-        su, so, se = exe_cmd(["verilator_coverage  -write-info", fdat+".info", fdat])
+        su, so, se = exe_cmd(["verilator_coverage  -write-info", fdat + ".info", fdat])
         assert su, f"Failed to convert line coverage({fdat}): {se}"
         ignore_text = []
         # find all .ignore files
@@ -62,10 +65,10 @@ def convert_line_coverage(line_coverage_list, output_dir):
                     assert c not in ln, f"Invalid line number({i}): '{ln}'"
                 ignore_text.append(f"\'{ln}\'")
         su, so, se = exe_cmd(
-                    ["lcov", "--remove", fdat+".info", " ".join(ignore_text), "--output-file", fdat+".info"]
-                )
+            ["lcov", "--remove", fdat + ".info", " ".join(ignore_text), "--output-file", fdat + ".info"]
+        )
         assert su, f"Failed to remove line with file: '{ignore_file_list}', exception: {se}"
-        coverage_info_list.append(fdat+".info")
+        coverage_info_list.append(fdat + ".info")
         final_ignore_info.append([fdat, copy.deepcopy(ignore_file_list)])
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
@@ -76,45 +79,53 @@ def convert_line_coverage(line_coverage_list, output_dir):
     return parse_lines(so), final_ignore_info
 
 
-def lcov_merge_and_del(list_to_merge, out_file, max_kbytes = 10, deepth = 0):
-    import time
-    stamp = "/tmp/%s_MINFO_%s_" % (deepth, time.time()) + "%s.tmpinfo"
-    batch_input, merged_input = [], []
-    total_size = 0
-    batch_index = 0
-    for f in list_to_merge:
-        assert os.path.exists(f), f"Invalid file: '{f}'"
-        if total_size + len(f) > max_kbytes * 1024 and len(batch_input) > 1:
-            _lcov_del_merge(batch_input, stamp % batch_index)
-            total_size = 0
-            for f_del in batch_input:
-                os.remove(f_del)
-            batch_input = []
-            batch_index += 1
-            merged_input.append(stamp % batch_index)
-            continue
-        batch_input.append(f)
-        total_size += len(f)
-    if len(batch_input) > 0:
-        if len(merged_input) < 1:
-            _lcov_del_merge(batch_input, out_file)
-            return
-        else:
-            _lcov_del_merge(batch_input, stamp % batch_index)
-            merged_input.append(stamp % batch_index)
-    return lcov_merge_and_del(merged_input, out_file, max_kbytes, deepth + 1)
+def lcov_merge_and_del(list_to_merge: List[str], out_file: str, max_kbytes=10) -> None:
+    def create_temp_file() -> str:
+        _, path = tempfile.mkstemp(prefix="merge_", suffix=".info")
+        return path
 
-
-def _lcov_del_merge(list_to_merge, out_file):
-    if len(list_to_merge) == 1:
-        os.rename(list_to_merge[0], out_file)
-        return
-    if len(list_to_merge) == 0:
-        return
-    su, so, se = exe_cmd(["lcov", *["-a '%s'" % f.replace('[', '\\[').replace(']', '\\]') for f in list_to_merge], "-o", out_file])
-    assert su, f"Failed to merge line coverage: {se}"
+    max_bytes = max_kbytes * 1024
+    cmd_list = ["lcov", "-o", out_file, "-a", out_file]
+    cmd_len = len(" ".join(cmd_list)) + 1
+    temp_total_size = cmd_len
+    temp_files = []
+    total_size = cmd_len
+    raw = 0
+    cooking = 0
+    for cooking in range(len(list_to_merge)):
+        f = list_to_merge[cooking]
+        f_len = 3 + len(f)  # The length of '-a ' is 3
+        if f_len + total_size > max_bytes:
+            temp = create_temp_file()  # Create temp file
+            temp_files.append(temp)
+            temp_total_size += len(temp) + 3
+            _lcov_merge(itertools.islice(list_to_merge, raw, cooking), temp)  # Merge into the temp
+            total_size = cmd_len
+            raw = cooking
+        total_size += f_len
+    # There are still unmerged files here
+    temp = create_temp_file()
+    temp_files.append(temp)
+    _lcov_merge(itertools.islice(list_to_merge, raw, cooking + 1), temp)
+    # Delete .dat.info
     for f in list_to_merge:
         os.remove(f)
+    # If the number of temp files is also huge
+    if temp_total_size > max_bytes:
+        lcov_merge_and_del(temp_files, out_file)
+    else:
+        _lcov_merge(temp_files, out_file)
+    # Clean the temps
+    for f in temp_files:
+        os.remove(f)
+
+
+def _lcov_merge(list_to_merge: Iterable[str], out_file: str) -> None:
+    cmd = ["lcov", "-o", out_file]
+    for f in list_to_merge:
+        cmd.append("-a")
+        cmd.append(f)
+    subprocess.run(cmd, stdout=subprocess.PIPE, shell=False, check=True)
 
 
 def base64_encode(data):


### PR DESCRIPTION
This pr **REQUIRE PICKER VERSION AFTER `bc3570e`**.

This pr add `--no-func-cov` flag and refactor DUT creation:

- Add a `--no-func-cov` command-line option to disable functional coverage collection during test runs.
- Refactor the `create_dut` method to create the DUT instance before configuring waveform and coverage files.
- Improve the logic for generating report filenames and now use `SetWaveform` and `SetCoverage` for configuration.
- Add type hints to several functions for better code readability.